### PR TITLE
feat: Add initial OpenAI and Ollama LLM providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2300,11 +2300,59 @@
 						"default": "copilot-official",
 						"markdownDescription": "%github.copilot.config.languageModelProviderId%",
 						"scope": "machine-overridable",
-						"enum": ["copilot-official", "mock-provider"],
+						"enum": ["copilot-official", "mock-provider", "openai-user", "ollama"],
 						"enumDescriptions": [
 							"%github.copilot.config.languageModelProviderId.copilotOfficialDescription%",
-							"%github.copilot.config.languageModelProviderId.mockProviderDescription%"
+							"%github.copilot.config.languageModelProviderId.mockProviderDescription%",
+							"%github.copilot.config.languageModelProviderId.openaiUserDescription%",
+							"%github.copilot.config.languageModelProviderId.ollamaDescription%"
 						]
+					},
+					"github.copilot.chat.languageModelProviders.openaiUser.apiKey": {
+						"type": "string",
+						"markdownDescription": "%github.copilot.config.languageModelProviders.openaiUser.apiKey.description%",
+						"scope": "machine-overridable",
+						"tags": ["languageModelProviderSetting"]
+					},
+					"github.copilot.chat.languageModelProviders.openaiUser.modelId": {
+						"type": "string",
+						"default": "gpt-4-turbo-preview",
+						"markdownDescription": "%github.copilot.config.languageModelProviders.openaiUser.modelId.description%",
+						"scope": "machine-overridable",
+						"tags": ["languageModelProviderSetting"]
+					},
+					"github.copilot.chat.languageModelProviders.openaiUser.apiBaseUrl": {
+						"type": "string",
+						"default": "https://api.openai.com/v1",
+						"markdownDescription": "%github.copilot.config.languageModelProviders.openaiUser.apiBaseUrl.description%",
+						"scope": "machine-overridable",
+						"tags": ["languageModelProviderSetting"]
+					},
+					"github.copilot.chat.languageModelProviders.ollama.baseUrl": {
+						"type": "string",
+						"default": "http://localhost:11434",
+						"markdownDescription": "%github.copilot.config.languageModelProviders.ollama.baseUrl.description%",
+						"scope": "machine-overridable",
+						"tags": ["languageModelProviderSetting"]
+					},
+					"github.copilot.chat.languageModelProviders.ollama.modelId": {
+						"type": "string",
+						"markdownDescription": "%github.copilot.config.languageModelProviders.ollama.modelId.description%",
+						"scope": "machine-overridable",
+						"tags": ["languageModelProviderSetting"]
+					},
+					"github.copilot.chat.languageModelProviders.ollama.keepAliveTime": {
+						"type": "string",
+						"default": "5m",
+						"markdownDescription": "%github.copilot.config.languageModelProviders.ollama.keepAliveTime.description%",
+						"scope": "machine-overridable",
+						"tags": ["languageModelProviderSetting"]
+					},
+					 "github.copilot.chat.languageModelProviders.ollama.embeddingModelId": {
+						"type": "string",
+						"markdownDescription": "%github.copilot.config.languageModelProviders.ollama.embeddingModelId.description%",
+						"scope": "machine-overridable",
+						"tags": ["languageModelProviderSetting"]
 					}
 				}
 			},

--- a/package.nls.json
+++ b/package.nls.json
@@ -295,5 +295,14 @@
 	"copilot.toolSet.runTasks.description": "Run tasks in your workspace",
 	"github.copilot.config.languageModelProviderId": "Selects the Language Model Provider to use for Copilot Chat features. Requires a reload to take effect.",
 	"github.copilot.config.languageModelProviderId.copilotOfficialDescription": "Uses the official GitHub Copilot language model service.",
-	"github.copilot.config.languageModelProviderId.mockProviderDescription": "Uses a mock provider for testing and development. Returns predefined responses."
+	"github.copilot.config.languageModelProviderId.mockProviderDescription": "Uses a mock provider for testing and development. Returns predefined responses.",
+	"github.copilot.config.languageModelProviderId.openaiUserDescription": "Uses OpenAI models with a user-provided API key.",
+	"github.copilot.config.languageModelProviderId.ollamaDescription": "Uses a locally running Ollama instance.",
+	"github.copilot.config.languageModelProviders.openaiUser.apiKey.description": "Your OpenAI API key. This will be stored securely.",
+	"github.copilot.config.languageModelProviders.openaiUser.modelId.description": "The OpenAI model ID to use (e.g., gpt-4-turbo-preview, gpt-3.5-turbo).",
+	"github.copilot.config.languageModelProviders.openaiUser.apiBaseUrl.description": "Optional: The base URL for the OpenAI API compatible endpoint.",
+	"github.copilot.config.languageModelProviders.ollama.baseUrl.description": "The base URL for your Ollama instance (e.g., http://localhost:11434).",
+	"github.copilot.config.languageModelProviders.ollama.modelId.description": "The Ollama model ID to use (e.g., llama2:7b, codellama:13b). Ensure the model is pulled in Ollama.",
+	"github.copilot.config.languageModelProviders.ollama.keepAliveTime.description": "Controls how long models stay loaded in memory in Ollama (e.g., 5m, 1h).",
+	"github.copilot.config.languageModelProviders.ollama.embeddingModelId.description": "Optional: The Ollama model ID to use for embeddings, if different from the chat model."
 }

--- a/src/extension/extension/vscode/extension.ts
+++ b/src/extension/extension/vscode/extension.ts
@@ -16,6 +16,8 @@ import { ContributionCollection, IExtensionContributionFactory } from '../../com
 import { ILanguageModelService } from '../../../platform/languageModel/common/languageModelService';
 import { CopilotOfficialLanguageModelProvider } from '../../../platform/languageModel/node/copilotOfficialLanguageModelProvider';
 import { MockLanguageModelProvider } from '../../../platform/languageModel/node/mockLanguageModelProvider';
+import { OpenAIUserLanguageModelProvider } from '../../../platform/languageModel/node/openaiUserLanguageModelProvider';
+import { OllamaLanguageModelProvider } from '../../../platform/languageModel/node/ollamaLanguageModelProvider'; // Added import
 import { ILogService } from '../../../platform/log/common/logService';
 
 // ##################################################################################
@@ -129,6 +131,17 @@ export function createInstantiationService(configuration: IExtensionActivationCo
 					languageModelService.registerProvider(mockProvider);
 					logService.info('Successfully registered MockLanguageModelProvider with LanguageModelService.');
 				}
+
+				// Register OpenAI User Provider
+				const openaiUserProvider = instantiationService.createInstance(OpenAIUserLanguageModelProvider);
+				languageModelService.registerProvider(openaiUserProvider);
+				logService.info('Successfully registered OpenAIUserLanguageModelProvider with LanguageModelService.');
+
+				// Register Ollama Provider
+				const ollamaProvider = instantiationService.createInstance(OllamaLanguageModelProvider);
+				languageModelService.registerProvider(ollamaProvider);
+				logService.info('Successfully registered OllamaLanguageModelProvider with LanguageModelService.');
+
 			} else {
 				logService.error('LanguageModelService not available to register providers.');
 			}

--- a/src/platform/languageModel/node/ollamaLanguageModelProvider.ts
+++ b/src/platform/languageModel/node/ollamaLanguageModelProvider.ts
@@ -1,0 +1,162 @@
+import { CancellationToken } from 'vscode';
+import { LanguageModelChatMessage, LanguageModelChatRequest, LanguageModelChatResponseChunk, LanguageModelCapabilities, ILanguageModelProvider, LanguageModelError } from '../common/languageModelProvider';
+import { IVSCodeConfigurationService } from '../../../platform/configuration/common/configuration';
+import { IFetcherService } from '../../../platform/networking/common/fetcherService'; // For API calls
+import { APIUsage } from '../../../platform/networking/common/openai'; // Assuming usage structure is compatible
+
+const OLLAMA_PROVIDER_ID = 'ollama';
+
+export class OllamaLanguageModelProvider implements ILanguageModelProvider {
+    readonly id: string = OLLAMA_PROVIDER_ID;
+    readonly displayName: string = 'Ollama (Local)';
+
+    constructor(
+        @IVSCodeConfigurationService private readonly configurationService: IVSCodeConfigurationService,
+        @IFetcherService private readonly fetcherService: IFetcherService
+    ) {}
+
+    private getBaseUrl(): string {
+        return this.configurationService.inspect<string>('github.copilot.chat.languageModelProviders.ollama.baseUrl')?.machineOverridableValue || 'http://localhost:11434';
+    }
+
+    private getModelId(): string {
+        return this.configurationService.inspect<string>('github.copilot.chat.languageModelProviders.ollama.modelId')?.machineOverridableValue || '';
+    }
+
+    async isAvailable(cancellationToken: CancellationToken): Promise<boolean> {
+        const baseUrl = this.getBaseUrl();
+        try {
+            // Attempt to hit a lightweight Ollama endpoint (e.g., /api/tags or just /)
+            const response = await this.fetcherService.fetch(`${baseUrl}/api/tags`, { method: 'GET' }, cancellationToken);
+            return response.ok;
+        } catch (error) {
+            console.error('Ollama provider isAvailable check failed:', error);
+            return false;
+        }
+    }
+
+    async getCapabilities(cancellationToken: CancellationToken): Promise<LanguageModelCapabilities> {
+        // TODO: Ideally, fetch /api/show for the configured modelId to get actual context window.
+        // For now, using a common default.
+        // Tool usage is generally not supported by Ollama's standard API in an OpenAI-compatible way.
+        return {
+            streaming: true,
+            maxContextTokens: 4096, // Common default, should be made dynamic
+            toolUsage: false,
+            supportedModels: [] // Can be populated dynamically by /api/tags if desired
+        };
+    }
+
+    async* streamChatCompletions(request: LanguageModelChatRequest, cancellationToken: CancellationToken): AsyncIterable<LanguageModelChatResponseChunk> {
+        const modelId = this.getModelId();
+        if (!modelId) {
+            throw new LanguageModelError('Ollama model ID is not configured. Please set it in the extension settings.', this.id);
+        }
+        const baseUrl = this.getBaseUrl();
+        const endpoint = `${baseUrl}/api/chat`;
+
+        const ollamaMessages = request.messages.map(m => ({
+            role: m.role === 'assistant' ? 'assistant' : (m.role === 'system' ? 'system' : 'user'), // Ollama uses 'user', 'assistant', 'system'
+            content: m.content,
+            // TODO: Handle images if Ollama provider/model supports it
+        }));
+
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+        };
+
+        const body: Record<string, any> = {
+            model: modelId,
+            messages: ollamaMessages,
+            stream: true,
+            options: { // Common Ollama options
+                temperature: request.temperature,
+                num_predict: request.maxTokens, // num_predict is often used for maxTokens
+                stop: request.stop,
+                // TODO: Map other options if available/relevant, e.g. top_p, top_k from request if we add them
+            }
+        };
+
+        // Remove undefined properties from body.options and body itself
+        if (body.options) {
+            Object.keys(body.options).forEach(key => body.options[key] === undefined && delete body.options[key]);
+            if (Object.keys(body.options).length === 0) {
+                delete body.options;
+            }
+        }
+        Object.keys(body).forEach(key => body[key] === undefined && delete body[key]);
+
+
+        const fetchOptions: IFetchOptions = {
+            method: 'POST',
+            headers: headers,
+            body: JSON.stringify(body),
+            signal: cancellationToken,
+            stream: true
+        };
+
+        let response: IFetchResponse;
+        try {
+            response = await this.fetcherService.fetch(endpoint, fetchOptions, cancellationToken);
+        } catch (error: any) {
+            this.logService.error(`[${this.id}] Network error calling Ollama:`, error);
+            throw new LanguageModelError(`Network error: ${error.message || 'Unknown network error'}`, this.id, error);
+        }
+
+        if (!response.ok) {
+            let errorBodyText = `Ollama API Error: ${response.status}`;
+            try {
+                const errorData = await response.json() as { error?: string };
+                if (errorData.error) {
+                    errorBodyText += ` - ${errorData.error}`;
+                }
+                this.logService.error(`[${this.id}] Ollama API error: ${response.status}`, errorData);
+                throw new LanguageModelError(errorBodyText, this.id, errorData, String(response.status));
+            } catch (e: any) {
+                 this.logService.error(`[${this.id}] Failed to parse Ollama error response:`, e);
+                throw new LanguageModelError(errorBodyText, this.id, e, String(response.status));
+            }
+        }
+
+        if (!response.body) {
+            throw new LanguageModelError('No response body from Ollama stream.', this.id);
+        }
+
+        const responseBodyStream = response.body as unknown as Readable;
+
+        for await (const chunk of streamToAsyncIterable(responseBodyStream)) {
+            if (cancellationToken.isCancellationRequested) {
+                if (typeof (responseBodyStream as any).destroy === 'function') {
+                    (responseBodyStream as any).destroy();
+                }
+                this.logService.info(`[${this.id}] Ollama stream cancelled.`);
+                throw new LanguageModelError('Stream cancelled by user.', this.id);
+            }
+
+            // Ollama streams JSON objects separated by newlines
+            const lines = chunk.toString().split('\n').filter(line => line.trim() !== '');
+            for (const line of lines) {
+                try {
+                    const parsed = JSON.parse(line);
+                    const responseChunk: LanguageModelChatResponseChunk = {
+                        content: parsed.message?.content || undefined,
+                        role: parsed.message?.role || 'assistant', // Default to assistant
+                        finishReason: parsed.done ? 'stop' : undefined, // Ollama's `done` field indicates end of stream
+                        usage: parsed.done && (parsed.prompt_eval_count || parsed.eval_count) ? {
+                            prompt_tokens: parsed.prompt_eval_count || 0,
+                            completion_tokens: parsed.eval_count || 0,
+                            total_tokens: (parsed.prompt_eval_count || 0) + (parsed.eval_count || 0)
+                        } as APIUsage : undefined
+                    };
+                    yield responseChunk;
+
+                    if (parsed.done) {
+                        return; // End of stream
+                    }
+                } catch (e: any) {
+                    this.logService.warn(`[${this.id}] Failed to parse Ollama stream data chunk: '${line}'`, e);
+                }
+            }
+        }
+    }
+}

--- a/src/platform/languageModel/node/openaiUserLanguageModelProvider.ts
+++ b/src/platform/languageModel/node/openaiUserLanguageModelProvider.ts
@@ -1,0 +1,180 @@
+import { CancellationToken, ExtensionContext } from 'vscode';
+import { LanguageModelChatMessage, LanguageModelChatRequest, LanguageModelChatResponseChunk, LanguageModelCapabilities, ILanguageModelProvider, LanguageModelError } from '../common/languageModelProvider';
+import { IVSCodeConfigurationService } from '../../../platform/configuration/common/configuration';
+import { APIUsage, OpenAIError, OpenAIErrorResponse } from '../../../platform/networking/common/openai'; // Assuming this path is correct, Added OpenAIError, OpenAIErrorResponse
+import { IExtensionContext } from '../../../platform/extContext/common/extensionContext';
+import { IFetcherService, IFetchOptions, IFetchResponse } from '../../../platform/networking/common/fetcherService'; // Import IFetcherService
+import { streamToAsyncIterable } from '../../../util/common/async'; // Utility to convert Node.js stream to AsyncIterable
+import { Readable } from 'stream';
+import { ILogService } from '../../../platform/log/common/logService';
+
+const OPENAI_USER_PROVIDER_ID = 'openai-user';
+const OPENAI_API_KEY_SECRET_KEY = 'openaiUser.apiKey'; // Key for VS Code SecretStorage
+
+export class OpenAIUserLanguageModelProvider implements ILanguageModelProvider {
+    readonly id: string = OPENAI_USER_PROVIDER_ID;
+    readonly displayName: string = 'OpenAI (User Key)';
+
+    constructor(
+        @IVSCodeConfigurationService private readonly configurationService: IVSCodeConfigurationService,
+        @IExtensionContext private readonly extensionContext: IExtensionContext,
+        @IFetcherService private readonly fetcherService: IFetcherService, // Inject IFetcherService
+        @ILogService private readonly logService: ILogService
+    ) {}
+
+    private async getApiKey(cancellationToken: CancellationToken): Promise<string | undefined> {
+        let apiKey = await this.extensionContext.secrets.get(OPENAI_API_KEY_SECRET_KEY);
+
+        if (!apiKey) {
+            // Fallback: Check configuration if not in SecretStorage (e.g., for migration or if user set it there directly)
+            const configApiKey = this.configurationService.inspect<string>(`github.copilot.chat.languageModelProviders.openaiUser.apiKey`)?.machineOverridableValue;
+            if (configApiKey) {
+                // If found in config, store it in SecretStorage and clear from config for security.
+                // Note: Clearing from config requires a command or different flow, as providers shouldn't directly write global/workspace settings.
+                // For now, we'll just use it and recommend users move it.
+                // A better approach would be a dedicated command to set/migrate the API key.
+                // await this.extensionContext.secrets.store(OPENAI_API_KEY_SECRET_KEY, configApiKey);
+                // Consider logging a recommendation to move the key.
+                apiKey = configApiKey;
+            }
+        }
+        return apiKey;
+    }
+
+    async isAvailable(cancellationToken: CancellationToken): Promise<boolean> {
+        const apiKey = await this.getApiKey(cancellationToken);
+        // TODO: Potentially validate the key with a lightweight API call to OpenAI.
+        return !!apiKey;
+    }
+
+    async getCapabilities(cancellationToken: CancellationToken): Promise<LanguageModelCapabilities> {
+        // These are typical capabilities for models like gpt-4 or gpt-3.5-turbo.
+        // maxContextTokens might need to be dynamic based on the selected modelId.
+        return {
+            streaming: true,
+            maxContextTokens: 8192, // Default, can be made dynamic later
+            toolUsage: true, // OpenAI models generally support tool/function calling
+            supportedModels: [ // Examples
+                'gpt-4-turbo-preview',
+                'gpt-4',
+                'gpt-3.5-turbo',
+                'gpt-3.5-turbo-16k'
+            ]
+        };
+    }
+
+    async* streamChatCompletions(request: LanguageModelChatRequest, cancellationToken: CancellationToken): AsyncIterable<LanguageModelChatResponseChunk> {
+        const apiKey = await this.getApiKey(cancellationToken);
+        if (!apiKey) {
+            throw new LanguageModelError('OpenAI API key is not configured. Please set it in the extension settings or use a dedicated command to set it.', this.id);
+        }
+
+        const modelId = this.configurationService.inspect<string>(`github.copilot.chat.languageModelProviders.openaiUser.modelId`)?.machineOverridableValue || 'gpt-3.5-turbo'; // Default model
+        const apiBaseUrl = this.configurationService.inspect<string>(`github.copilot.chat.languageModelProviders.openaiUser.apiBaseUrl`)?.machineOverridableValue || 'https://api.openai.com/v1';
+
+        const endpoint = `${apiBaseUrl}/chat/completions`;
+
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`
+        };
+
+        const body: Record<string, any> = {
+            model: request.modelId || modelId,
+            messages: request.messages,
+            stream: true,
+            temperature: request.temperature,
+            max_tokens: request.maxTokens,
+            stop: request.stop,
+            user: request.user
+        };
+
+        // Remove undefined properties from body
+        Object.keys(body).forEach(key => body[key] === undefined && delete body[key]);
+
+        const fetchOptions: IFetchOptions = {
+            method: 'POST',
+            headers: headers,
+            body: JSON.stringify(body),
+            signal: cancellationToken,
+            stream: true // Important for IFetcherService to handle streaming
+        };
+
+        let response: IFetchResponse;
+        try {
+            response = await this.fetcherService.fetch(endpoint, fetchOptions, cancellationToken);
+        } catch (error: any) {
+            this.logService.error(`[${this.id}] Network error calling OpenAI:`, error);
+            throw new LanguageModelError(`Network error: ${error.message || 'Unknown network error'}`, this.id, error);
+        }
+
+        if (!response.ok) {
+            let errorBodyText = 'Unknown error';
+            try {
+                errorBodyText = await response.text();
+                const errorJson = JSON.parse(errorBodyText) as OpenAIErrorResponse;
+                const errorMessage = errorJson.error?.message || errorBodyText;
+                this.logService.error(`[${this.id}] OpenAI API error: ${response.status}`, errorMessage, errorJson);
+                throw new LanguageModelError(`API Error: ${response.status} ${errorMessage}`, this.id, errorJson, String(response.status));
+            } catch (e: any) {
+                this.logService.error(`[${this.id}] Failed to parse OpenAI error response:`, errorBodyText, e);
+                throw new LanguageModelError(`API Error: ${response.status} - ${errorBodyText}`, this.id, e, String(response.status));
+            }
+        }
+
+        if (!response.body) {
+            throw new LanguageModelError('No response body from OpenAI stream.', this.id);
+        }
+
+        // Convert Node.js Readable stream from fetcherService to AsyncIterable
+        const responseBodyStream = response.body as unknown as Readable;
+
+        for await (const chunk of streamToAsyncIterable(responseBodyStream)) {
+            if (cancellationToken.isCancellationRequested) {
+                // Ensure the stream is properly closed/destroyed if cancellation happens mid-stream.
+                // The `fetch` signal should handle aborting the request, but cleaning up the stream reader is good practice.
+                if (typeof (responseBodyStream as any).destroy === 'function') {
+                    (responseBodyStream as any).destroy();
+                }
+                this.logService.info(`[${this.id}] OpenAI stream cancelled.`);
+                throw new LanguageModelError('Stream cancelled by user.', this.id);
+            }
+
+            const lines = chunk.toString().split('\n');
+            for (const line of lines) {
+                if (line.startsWith('data: ')) {
+                    const dataContent = line.substring('data: '.length).trim();
+                    if (dataContent === '[DONE]') {
+                        // Stream finished. Sometimes OpenAI sends usage stats in a final non-data: [DONE] chunk or a separate header.
+                        // For now, we assume usage might come with the last data chunk if `finish_reason` is present.
+                        return;
+                    }
+                    if (dataContent) {
+                        try {
+                            const parsed = JSON.parse(dataContent);
+                            if (parsed.choices && parsed.choices.length > 0) {
+                                const choice = parsed.choices[0];
+                                const responseChunk: LanguageModelChatResponseChunk = {
+                                    content: choice.delta?.content || undefined,
+                                    role: choice.delta?.role || undefined,
+                                    finishReason: choice.finish_reason || undefined,
+                                    // OpenAI often sends usage in the *last* chunk of a non-streaming response,
+                                    // or sometimes as a separate header/field in streaming.
+                                    // For streaming, `usage` is typically on the *final* data event if `finish_reason` is set.
+                                    // Or sometimes in an `x-request-id` header or similar on the main response (not accessible here directly per chunk).
+                                    // Let's assume for now if finish_reason is present, and 'usage' exists in the parsed chunk, we use it.
+                                    // This part needs to be verified against actual OpenAI streaming behavior for token counts.
+                                    usage: parsed.usage || choice.usage || undefined // Check root and choice for usage
+                                };
+                                yield responseChunk;
+                            }
+                        } catch (e: any) {
+                            this.logService.warn(`[${this.id}] Failed to parse OpenAI stream data chunk: '${dataContent}'`, e);
+                            // Decide if we should throw or just skip this malformed chunk
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the initial implementation for two new pluggable language model providers:

1.  **OpenAI (User Key) Provider:**
    *   Allows users to configure their own OpenAI API key (retrieved from SecretStorage or settings) and select an OpenAI model.
    *   Implements `streamChatCompletions` to call the OpenAI API and stream responses.
    *   Configuration settings and NLS strings added.

2.  **Ollama Provider:**
    *   Enables connection to a local Ollama instance.
    *   Users can configure the Ollama base URL and model ID.
    *   Implements `streamChatCompletions` to call the Ollama API and stream responses.
    *   Configuration settings and NLS strings added.

Both providers are registered with the `ILanguageModelService` during extension activation.

Further work will include more robust API key handling for OpenAI, dynamic capability fetching for Ollama, and comprehensive testing.